### PR TITLE
Show both temps for Ecobee3

### DIFF
--- a/Ecobee.indigoPlugin/Contents/Server Plugin/ecobee_devices.py
+++ b/Ecobee.indigoPlugin/Contents/Server Plugin/ecobee_devices.py
@@ -127,6 +127,7 @@ class EcobeeThermostat(EcobeeBase):
 		runtime = thermostat.get('runtime')
 		hsp = runtime.get('desiredHeat')
 		csp = runtime.get('desiredCool')
+		dispTemp = runtime.get('actualTemperature')
 		climate = thermostat.get('program').get('currentClimateRef')
 
 		settings = thermostat.get('settings')
@@ -145,7 +146,8 @@ class EcobeeThermostat(EcobeeBase):
 
 		self.name = matchedSensor.get('name')
 
-		self._update_server_temperature(matchedSensor, u'temperatureInput1')
+		self._update_server_smart_temperature(dispTemp, u'temperatureInput1')
+		self._update_server_temperature(matchedSensor, u'temperatureInput2')
 		self._update_server_occupancy(matchedSensor)
 
 		# humidity

--- a/Ecobee.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Ecobee.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -164,6 +164,8 @@ class Plugin(indigo.PluginBase):
 			# Add support for the thermostat's humidity sensor
 			newProps = dev.pluginProps
 			newProps["NumHumidityInputs"] = 1
+			# Ecobee3 have two temperatures - the one displayed on the thermostat and the one sensed at the thermostat
+			newProps["NumTemperatureInputs"] = 2
 			# SHENANIGANS: the following property has to be set in order for us to report
 			#   whether the thermostat is presently heating, cooling, etc.
 			#   This was difficult to find.


### PR DESCRIPTION
Shows both temps on Ecobee3:
temp 1 - temperature displayed on physical thermostat, usually the average of all sensors
temp 2 - temperature detected at the thermostat location