### PR TITLE
Add support for activating comfort settings (climates)

### DIFF
--- a/Ecobee.indigoPlugin/Contents/Server Plugin/Actions.xml
+++ b/Ecobee.indigoPlugin/Contents/Server Plugin/Actions.xml
@@ -27,4 +27,14 @@
 			</Field>
 		</ConfigUI>
 	</Action>
+	<Action id="activateComfortSetting" deviceFilter="self">
+		<Name>Activate Comfort Setting</Name>
+		<CallbackMethod>actionActivateComfortSetting</CallbackMethod>
+		<ConfigUI>
+			<Field id="climate" type="menu">
+				<Label>Comfort Setting:</Label>
+                <List class="self" filter="" method="climateListGenerator" dynamicReload="true"/>
+			</Field>
+		</ConfigUI>
+	</Action>
 </Actions>

--- a/Ecobee.indigoPlugin/Contents/Server Plugin/ecobee_devices.py
+++ b/Ecobee.indigoPlugin/Contents/Server Plugin/ecobee_devices.py
@@ -77,6 +77,16 @@ def _get_remote_sensor_json(ecobee, address):
 		if address == rs.get('code')
 	][0]
 
+def get_climates(ecobee, address):
+	return [
+		(rs.get('climateRef'), rs.get('name'))
+		for rs in _get_climates_json(ecobee, address)
+	]
+
+def _get_climates_json(ecobee, address):
+	thermostat = _get_thermostat_json(ecobee, address)
+	return thermostat.get('program').get('climates')
+
 def _get_capability(obj, cname):
 	ret = [c for c in obj.get('capability') if cname == c.get('type')][0]
 	return ret

--- a/Ecobee.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Ecobee.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -295,6 +295,27 @@ class Plugin(indigo.PluginBase):
 		# indigo.kThermostatAction.RequestDeadbands, indigo.kThermostatAction.RequestSetpoints]:
 		#	self._refreshStatesFromHardware(dev, True, False)
 
+	def climateListGenerator(self, filter, valuesDict, typeId, targetId):                                                                                                                 
+		for t in self.active_thermostats:
+			if t.dev.id == targetId:
+				retList = get_climates(self.ecobee, t.dev.address)
+		return retList
+
+	########################################
+	# Activate Comfort Setting callback
+	######################
+	def actionActivateComfortSetting(self, action, dev):
+		###### ACTIVATE COMFORT SETTING ######
+		climate = action.props.get("climate")
+
+		sendSuccess = False
+		if self.ecobee.set_climate_hold_id(dev.pluginProps["address"], climate) :
+			sendSuccess = True;
+			if sendSuccess:
+				indigo.server.log(u"sent set_climate_hold to %s" % dev.address)
+			else:
+				indigo.server.log(u"Failed to send set_climate_hold to %s" % dev.address, isError=True)
+
 	########################################
 	# Resume Program callback
 	######################

--- a/Ecobee.indigoPlugin/Contents/Server Plugin/pyecobee/__init__.py
+++ b/Ecobee.indigoPlugin/Contents/Server Plugin/pyecobee/__init__.py
@@ -278,6 +278,25 @@ class Ecobee(object):
                   " climate hold.  Refreshing tokens...")
             self.refresh_tokens()
 
+    def set_climate_hold_id(self, id, climate, hold_type="nextTransition"):
+        ''' Set a climate hold - ie away, home, sleep '''
+        url = 'https://api.ecobee.com/1/thermostat'
+        header = {'Content-Type': 'application/json;charset=UTF-8',
+                  'Authorization': 'Bearer ' + self.access_token}
+        params = {'format': 'json'}
+        body = ('{"functions":[{"type":"setHold","params":{"holdType":"'
+                + hold_type + '","holdClimateRef":"' + climate + '"}}],'
+                '"selection":{"selectionType":"thermostats","selectionMatch"'
+                ':"' + id  + '"}}')
+        request = requests.post(url, headers=header, params=params, data=body)
+        if request.status_code == requests.codes.ok:
+            self._invalidate_cache()
+            return request
+        else:
+            log.warning("Error connecting to Ecobee while attempting to set"
+                  " climate hold.  Refreshing tokens...")
+            self.refresh_tokens()
+
     def resume_program_id(self, id, resume_all="false"):
         ''' Resume currently scheduled program by ID '''
         url = 'https://api.ecobee.com/1/thermostat'


### PR DESCRIPTION
* Fetch the list of climates for a specific thermostat
* Display the list of climates as "Comfort Settings" in the plugin UI (this is done be consistent with what a user would see in the Ecobee web UI)
* Holds are currently hardcoded as "nextTransition". Support for custom holds will need to be added later